### PR TITLE
Removing Ubuntu 16.04 from public docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,7 +5,7 @@ orbs:
 jobs:
   build:
     machine:
-      image: ubuntu-1604:201903-01
+      image: ubuntu-2004:202201-02
     steps:
       - checkout
       - matlab/install

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: ubuntu-20.04
+  vmImage: ubuntu-latest
 steps:
   - task: InstallMATLAB@0
   - task: RunMATLABTests@0

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,5 +1,5 @@
 pool:
-  vmImage: Ubuntu 16.04
+  vmImage: ubuntu-20.04
 steps:
   - task: InstallMATLAB@0
   - task: RunMATLABTests@0


### PR DESCRIPTION
Updated the CircleCI and Azure DevOps examples to use Ubuntu 20.04